### PR TITLE
use c++11 if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+project(qt-virt-manager CXX)
+
 # TODO: make a cross platform here
 if (NOT CMAKE_INSTALL_PREFIX)
     set (CMAKE_INSTALL_PREFIX /usr)
@@ -6,6 +8,12 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 cmake_minimum_required (VERSION 2.8.3)
 include(CheckFunctionExists)
+include(CheckCXXCompilerFlag)
+
+CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+if(COMPILER_SUPPORTS_CXX11)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
 
 ##
 if ( NOT DEFAULT_ENCODING )


### PR DESCRIPTION
 Without -std=c++11 I got some warnings. I'm not sure if you want to enforce c++11 ( I would ). If so I guess a message with FATAL_ERROR should be added.
