### PR TITLE
musl fix

### DIFF
--- a/src/vm_viewer/main.cpp
+++ b/src/vm_viewer/main.cpp
@@ -5,6 +5,7 @@
 #if WITH_VNC_SUPPORT
 #include "vm_viewer/vnc/vnc_viewer_only.h"
 #endif
+#include "vm_viewer/vm_viewer_only.h"
 #include <QApplication>
 #include <QMessageBox>
 #include <QTranslator>


### PR DESCRIPTION
Fix build with musl when vnc support is not enabled

> vm_viewer/main.cpp:60:13: error: ‘VM_Viewer_Only’ was not declared in this scope
>              VM_Viewer_Only *w = nullptr;