### PR TITLE
Update qspice-widget.cpp

### DIFF
--- a/src/vm_viewer/qspice_widgets/qspice-widget.cpp
+++ b/src/vm_viewer/qspice_widgets/qspice-widget.cpp
@@ -352,7 +352,7 @@ void QSpiceWidget::setChannel(QSpiceChannel *channel)
         online = record->connectToChannel();
         //qDebug()<<"USE_SPICE_AUDIO";
 #else
-        qDebug()<<"NOT USE_SPICE_AUDIO";
+        //qDebug()<<"NOT USE_SPICE_AUDIO";
 #endif
         if ( online && !spiceAudio ) {
             spiceAudio = new QSpiceAudio(


### PR DESCRIPTION
```
 /var/tmp/portage/app-emulation/qt-virt-manager-9999/work/qt-virt-manager-9999/src/vm_viewer/qspice_widgets/qspice-widget.cpp:355:16: error: invalid use of incomplete type ‘class QDebug’
qDebug()<<"NOT USE_SPICE_AUDIO";
```

Happen when USE_SPICE_AUDIO = OFF
